### PR TITLE
fixed interchanged distance/duration values

### DIFF
--- a/python/Dieselgate_Routing.ipynb
+++ b/python/Dieselgate_Routing.ipynb
@@ -101,7 +101,7 @@
     "regular_route = clnt.directions(**direction_params) # Direction request\n",
     "\n",
     "# Build popup\n",
-    "duration, distance = regular_route['features'][0]['properties']['summary'].values()\n",
+    "distance, duration = regular_route['features'][0]['properties']['summary'].values()\n",
     "popup = folium.map.Popup(popup_route.format('Regular', \n",
     "                                                 duration/60, \n",
     "                                                 distance/1000))\n",


### PR DESCRIPTION
The distance and duration attributes were interchanged in 'Dieselgate_Routing' notebook.